### PR TITLE
CI: Make routines reusable and enable PR tests

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -55,7 +55,7 @@ runs:
       with:
         version: ${{ inputs.emscripten_version }}
         actions-cache-folder: emsdk-cache
-        cache-key: emsdk-${{ env.SCONS_PLATFORM }}-main
+        cache-key: emsdk-${{ env.SCONS_PLATFORM }}-${{ env.GIT_BASE_REF }}-${{ inputs.emscripten_version }}
 
     - name: "Web: Verify Emscripten"
       if: ${{ env.SCONS_PLATFORM == 'web' }}

--- a/.github/actions/publish-extension/action.yml
+++ b/.github/actions/publish-extension/action.yml
@@ -8,6 +8,8 @@ inputs:
     default: "bin"
   platform:
     default: ""
+  release-version:
+    required: true
 
 runs:
   using: "composite"
@@ -19,9 +21,9 @@ runs:
         path: ${{ inputs.path }}
         filename: libgdsion-${{ inputs.platform }}.zip
 
-    - name: Update the rolling release with the artifact
+    - name: Update the release with the platform artifact
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        gh release upload latest-unstable ${{ inputs.directory }}/libgdsion-${{ inputs.platform }}.zip --clobber
+        gh release upload ${{ inputs.release-version }} ${{ inputs.directory }}/libgdsion-${{ inputs.platform }}.zip --clobber

--- a/.github/actions/setup-cache/action.yml
+++ b/.github/actions/setup-cache/action.yml
@@ -7,4 +7,21 @@ runs:
     - uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/.scons-cache/
-        key: ${{ env.SCONS_PLATFORM }}${{ env.SCONS_PLATFORM_SUFFIX }}-main
+        key: ${{ env.SCONS_PLATFORM }}${{ env.SCONS_PLATFORM_SUFFIX }}-${{ env.GIT_BASE_REF }}-${{ github.ref }}-${{ github.sha }}
+
+        # We try to match an existing cache to restore from it. Each potential key is checked against
+        # all existing caches as a prefix. E.g. 'windows-x86_64' would match any cache that starts with
+        # "windows-x86_64", such as "windows-x86_64-master-refs/heads/master-6588a4a29af1621086feac0117d5d4d37af957fd".
+        #
+        # We check these prefixes in this order:
+        #
+        #   1. The exact match, including the base branch, the commit reference, and the SHA hash of the commit.
+        #   2. A partial match for the same base branch and the same commit reference.
+        #   3. A partial match for the same base branch and the base branch commit reference.
+        #   4. A partial match for the same base branch only (not ideal, matches any PR with the same base branch).
+
+        restore-keys: |
+          ${{ env.SCONS_PLATFORM }}${{ env.SCONS_PLATFORM_SUFFIX }}-${{ env.GIT_BASE_REF }}-${{ github.ref }}-${{ github.sha }}
+          ${{ env.SCONS_PLATFORM }}${{ env.SCONS_PLATFORM_SUFFIX }}-${{ env.GIT_BASE_REF }}-${{ github.ref }}
+          ${{ env.SCONS_PLATFORM }}${{ env.SCONS_PLATFORM_SUFFIX }}-${{ env.GIT_BASE_REF }}-refs/heads/${{ env.GIT_BASE_REF }}
+          ${{ env.SCONS_PLATFORM }}${{ env.SCONS_PLATFORM_SUFFIX }}-${{ env.GIT_BASE_REF }}

--- a/.github/actions/update-release/action.yml
+++ b/.github/actions/update-release/action.yml
@@ -1,0 +1,29 @@
+name: Update GitHub Release
+description: Update the tag of an existing GH Release, and republish it.
+
+inputs:
+  release-version:
+    required: true
+  republish:
+    default: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Update the release tag
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        git tag -d ${{ inputs.release-version }}
+        git push origin :refs/tags/${{ inputs.release-version }}
+        git tag ${{ inputs.release-version }} ${{ git.sha }}
+        git push origin ${{ inputs.release-version }}
+
+    - name: Republish the release
+      if: ${{ inputs.republish }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh release edit ${{ inputs.release-version }} --draft=false

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -1,0 +1,40 @@
+name: Build and Test Pull Request
+
+on:
+  pull_request:
+
+# Make sure jobs cannot overlap.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+# First, build the extension and upload the artifacts.
+
+  build-linux:
+    name: Compile and upload Linux version
+    uses: ./.github/workflows/extension-build-linux.yml
+
+  build-macos:
+    name: Compile and upload macOS version
+    uses: ./.github/workflows/extension-build-macos.yml
+
+  build-windows:
+    name: Compile and upload Windows version
+    uses: ./.github/workflows/extension-build-windows.yml
+
+  build-web:
+    name: Compile and upload Web version
+    uses: ./.github/workflows/extension-build-web.yml
+
+  build-android:
+    name: Compile and upload Android version
+    uses: ./.github/workflows/extension-build-android.yml
+
+# Then, use the artifacts to test the example project.
+
+  export-example-project:
+    name: Export the example project for target platforms
+    needs: [ build-linux, build-macos, build-windows, build-web, build-android ]
+    uses: ./.github/workflows/example-export-project.yml

--- a/.github/workflows/build-release-unstable.yml
+++ b/.github/workflows/build-release-unstable.yml
@@ -1,4 +1,4 @@
-name: Build Unstable (main branch)
+name: Build and Publish Unstable (main branch)
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
 
 # Make sure jobs cannot overlap.
 concurrency:
-  group: build-unstable-main
+  group: build-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -40,6 +40,8 @@ jobs:
     name: Package and publish the extension
     needs: [ build-linux, build-macos, build-windows, build-web, build-android ]
     uses: ./.github/workflows/extension-publish-all.yml
+    with:
+      release-version: 'latest-unstable'
 
   export-example-project:
     name: Export the example project for target platforms
@@ -50,3 +52,19 @@ jobs:
     name: Package and publish the example project
     needs: [ export-example-project ]
     uses: ./.github/workflows/example-publish-project.yml
+    with:
+      release-version: 'latest-unstable'
+
+# Lastly, update the release tag and republish it.
+
+  release-all:
+    name: Update tag and re-release the GitHub Release
+    needs: [ publish-all, publish-example-project ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update GitHub Release
+        uses: ./.github/actions/update-release
+        with:
+          release-version: 'latest-unstable'
+          republish: true
+

--- a/.github/workflows/example-export-project.yml
+++ b/.github/workflows/example-export-project.yml
@@ -5,7 +5,7 @@ on:
 
 # Make sure jobs cannot overlap.
 concurrency:
-  group: export-unstable-example-project
+  group: export-${{ github.ref }}-example-project
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/example-publish-project.yml
+++ b/.github/workflows/example-publish-project.yml
@@ -2,10 +2,14 @@ name: Publish Example Project
 
 on:
   workflow_call:
+    inputs:
+      release-version:
+        required: true
+        type: string
 
 # Make sure jobs cannot overlap.
 concurrency:
-  group: publish-unstable-example-project
+  group: publish-${{ github.ref }}-example-project
   cancel-in-progress: true
 
 jobs:
@@ -41,11 +45,11 @@ jobs:
           directory: example/export
           split: true
 
-      - name: Update the rolling release with the example project
+      - name: Update the release with the example project
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload latest-unstable example/example-project-source.zip --clobber
-          gh release upload latest-unstable example/export/*.zip --clobber
+          gh release upload ${{ inputs.release-version }} example/example-project-source.zip --clobber
+          gh release upload ${{ inputs.release-version }} example/export/*.zip --clobber
 

--- a/.github/workflows/extension-build-android.yml
+++ b/.github/workflows/extension-build-android.yml
@@ -5,7 +5,7 @@ on:
 
 # Make sure jobs cannot overlap.
 concurrency:
-  group: build-unstable-main-android
+  group: build-${{ github.ref }}-android
   cancel-in-progress: true
 
 jobs:
@@ -18,6 +18,7 @@ jobs:
     name: Compile and upload Android (${{ matrix.arch }}) version
     runs-on: ubuntu-latest
     env:
+      GIT_BASE_REF: 'main'
       SCONS_PLATFORM: android
       SCONS_PLATFORM_SUFFIX: ".${{ matrix.arch }}"
 

--- a/.github/workflows/extension-build-linux.yml
+++ b/.github/workflows/extension-build-linux.yml
@@ -5,7 +5,7 @@ on:
 
 # Make sure jobs cannot overlap.
 concurrency:
-  group: build-unstable-main-linux
+  group: build-${{ github.ref }}-linux
   cancel-in-progress: true
 
 jobs:
@@ -13,6 +13,7 @@ jobs:
     name: Compile and upload Linux version
     runs-on: ubuntu-latest
     env:
+      GIT_BASE_REF: 'main'
       SCONS_PLATFORM: linux
 
     steps:

--- a/.github/workflows/extension-build-macos.yml
+++ b/.github/workflows/extension-build-macos.yml
@@ -5,7 +5,7 @@ on:
 
 # Make sure jobs cannot overlap.
 concurrency:
-  group: build-unstable-main-macos
+  group: build-${{ github.ref }}-macos
   cancel-in-progress: true
 
 jobs:
@@ -13,6 +13,7 @@ jobs:
     name: Compile and upload macOS version
     runs-on: macos-latest
     env:
+      GIT_BASE_REF: 'main'
       SCONS_PLATFORM: macos
 
     steps:

--- a/.github/workflows/extension-build-web.yml
+++ b/.github/workflows/extension-build-web.yml
@@ -5,7 +5,7 @@ on:
 
 # Make sure jobs cannot overlap.
 concurrency:
-  group: build-unstable-main-web
+  group: build-${{ github.ref }}-web
   cancel-in-progress: true
 
 jobs:
@@ -13,6 +13,7 @@ jobs:
     name: Compile and upload Web version
     runs-on: ubuntu-latest
     env:
+      GIT_BASE_REF: 'main'
       SCONS_PLATFORM: web
 
     steps:

--- a/.github/workflows/extension-build-windows.yml
+++ b/.github/workflows/extension-build-windows.yml
@@ -5,7 +5,7 @@ on:
 
 # Make sure jobs cannot overlap.
 concurrency:
-  group: build-unstable-main-windows
+  group: build-${{ github.ref }}-windows
   cancel-in-progress: true
 
 jobs:
@@ -18,6 +18,7 @@ jobs:
     name: Compile and upload Windows (${{ matrix.arch }}) version
     runs-on: windows-latest
     env:
+      GIT_BASE_REF: 'main'
       SCONS_PLATFORM: windows
       SCONS_PLATFORM_SUFFIX: ".${{ matrix.arch }}"
 

--- a/.github/workflows/extension-publish-all.yml
+++ b/.github/workflows/extension-publish-all.yml
@@ -2,10 +2,14 @@ name: Publish Extension
 
 on:
   workflow_call:
+    inputs:
+      release-version:
+        required: true
+        type: string
 
 # Make sure jobs cannot overlap.
 concurrency:
-  group: publish-unstable-main
+  group: publish-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -35,3 +39,4 @@ jobs:
           directory: artifacts
           path: bin
           platform: ${{ matrix.platform }}
+          release-version: ${{ inputs.release-version }}


### PR DESCRIPTION
This replaces instances of hardcoded `main` branch references and references to unstable version with dynamic properties. This allows to reuse all the same routines for PR testing and, in future, for static release builds.

This also includes another attempt at auto-updating the release tag for `latest-unstable`.

_This is done as a PR mostly to test the workflow._