### PR TITLE
Use HTTPS in submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "godot-cpp"]
 	path = godot-cpp
-	url = git@github.com:godotengine/godot-cpp.git
+	url = https://github.com/godotengine/godot-cpp.git


### PR DESCRIPTION
This makes packaging GDSiON simpler by removing the need of having ssh in the build environment.